### PR TITLE
Add area code 6 to south africa

### DIFF
--- a/lib/phonie/data/phone_countries.yml
+++ b/lib/phonie/data/phone_countries.yml
@@ -165,9 +165,9 @@
   :iso_3166_code: ZA
   :name: South Africa
   :international_dialing_prefix: '00'
-  :area_code: 800|86[01]|[1-57-8]\d
+  :area_code: 800|86[01]|[1-8]\d
   :local_number_format: \d{6,7}
-  :mobile_format: 7\d{8}|8[1-9]\d{7}
+  :mobile_format: (6|7)\d{8}|8[1-9]\d{7}
   :number_format: \d{9}
 -
   :country_code: '508'
@@ -1788,9 +1788,9 @@
   :iso_3166_code: MX
   :name: Mexico
   :international_dialing_prefix: '00'
-  :area_code: '1?(55|81|33|656|614|999|222|442|624|664|661|646|686|667|722|998|871|744|444|833|961|962|687)'
+  :area_code: '1?(([0-9][0-9]?)\d{8}|(([5][5-9])\d{1})\d{7}|(([0-4]|[6-9])\d{2})\d{7})'
   :local_number_format: '\d{7,8}'
-  :mobile_format: '1(55|81|33|656|614|999|222|442|664|624|661|646|686|667|722|998|871|744|444|833|961|962|687)\d{7,8}'
+  :mobile_format: '1?(([0-9][0-9]?)\d{8}|(([5][5-9])\d{1})\d{7}|(([0-4]|[6-9])\d{2})\d{7})'
   :number_format: '\d{10,11}'
 -
   :country_code: '220'

--- a/test/countries/za_test.rb
+++ b/test/countries/za_test.rb
@@ -10,6 +10,7 @@ class ZATest < Phonie::TestCase
   def test_mobile
     # Vodacom
     parse_test('+27 82 555 5555', '27', '82', '5555555', "South Africa", true)
+    parse_test('+27 61 555 5555', '27', '61', '5555555', "South Africa", true)
   end
 
   def test_tollfree


### PR DESCRIPTION
the original regex pattern specifically excluded 6 from the area codes,
however as seen in the wiki (and by a user on our system) this number
format is available (rarely) for mobile phone numbers.
