### PR TITLE
parse the number by area code match first if we know the country code

### DIFF
--- a/lib/phonie/parser.rb
+++ b/lib/phonie/parser.rb
@@ -37,10 +37,10 @@ module Phonie
     # Optionally a +default_area_code+ may be passed in order to
     # allow parsing local number numbers for a known area code
     def parse(number, default_area_code = nil)
-      parse_full_match(number) ||
-      parse_area_code_match(number) ||
-      parse_with_default(number, default_area_code) ||
-      {}
+      parsed_number = parse_area_code_match(number) if country_code.present?
+      parsed_number ||= parse_full_match(number)
+      parsed_number ||= parse_with_default(number, default_area_code)
+      parsed_number ||= {}
     end
 
     # Test if a phone number could possibly be valid by testing

--- a/lib/phonie/parser.rb
+++ b/lib/phonie/parser.rb
@@ -37,10 +37,10 @@ module Phonie
     # Optionally a +default_area_code+ may be passed in order to
     # allow parsing local number numbers for a known area code
     def parse(number, default_area_code = nil)
-      parsed_number = parse_area_code_match(number) if country_code.present?
-      parsed_number ||= parse_full_match(number)
-      parsed_number ||= parse_with_default(number, default_area_code)
-      parsed_number ||= {}
+      parse_full_match(number) ||
+      parse_area_code_match(number) ||
+      parse_with_default(number, default_area_code) ||
+      {}
     end
 
     # Test if a phone number could possibly be valid by testing
@@ -74,9 +74,11 @@ module Phonie
       string =~ number_regex && default_area_code =~ area_code_regex
     end
 
+    # check if existing country code matches regex country code
     def parse_full_match(number)
       match = number.match(full_number_regex)
       return nil unless match
+      return nil unless match[1] == country_code if !country_code.nil?
 
       { area_code: match[2],
         number:    match[-1] }


### PR DESCRIPTION
We were running into an issue with an Italian number that had an area code that was matching the country code.

This is the phone number: +39 393 2612345

We would pass this into phonie and get back an incorrect phone number:
`Phonie::Phone.parse("3932612345", country_code: "39").format("00%c%a%n")
=> "003932612345"
`

Phonie as it stands does a full number regex pattern match when it is attempting to parse, which checks for country code, area code and the number. 

**Full Number Match**
`Regexp.new("^[+]?(#{country_code})(#{area_code})(#{local_number_format})$")
`

The issue is 393 is the area code which contains the same numbers as the country code of 39.
326 is also a valid area code, phonie thinks this number is alright since it's still valid regex.

**Area Code Match**
`Regexp.new("^0?(#{area_code})(#{local_number_format})$")
`
This change simply checks if we know what the country code is and if so, do the area code regex match first.
